### PR TITLE
.live() is a deprecated function (from 1.7+) and removed completely from jQuery 1.9+

### DIFF
--- a/vendor/assets/javascripts/jquery.flexslider.js
+++ b/vendor/assets/javascripts/jquery.flexslider.js
@@ -200,7 +200,7 @@
           slider.controlNav = slider.manualControls;
           methods.controlNav.active();
           
-          slider.controlNav.live(eventType, function(event) {
+          slider.controlNav.on(eventType, function(event) {
             event.preventDefault();
             var $this = $(this),
                 target = slider.controlNav.index($this);
@@ -212,7 +212,7 @@
           });
           // Prevent iOS click event bug
           if (touch) {
-            slider.controlNav.live("click touchstart", function(event) {
+            slider.controlNav.on("click touchstart", function(event) {
               event.preventDefault();
             });
           }


### PR DESCRIPTION
Replacing .live() with .on().
http://api.jquery.com/on/ 
